### PR TITLE
Avoid duplicate toots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ lint:
 	mypy src/ utils/
 
 test:
-	pytest -v --cov --cov-report xml:coverage.xml --cov-report term tests/
+	pytest -v
+	# --cov --cov-report xml:coverage.xml --cov-report term tests/
 
 deploy:
 	sls deploy

--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,6 @@ test:
 
 deploy:
 	sls deploy
+
+run:
+	PYTHONPATH=./ flask --debug --app src/api.py run

--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ name = "pypi"
 flask = "*"
 "mastodon.py" = "*"
 flasgger = "*"
+boto3 = "*"
 
 [dev-packages]
 flake8 = "*"
@@ -16,6 +17,7 @@ mypy = "*"
 pytest = "*"
 pytest-cov = "*"
 freezegun = "*"
+boto3-stubs = "*"
 
 [requires]
 python_version = "3.12"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -41,28 +41,28 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:b41deed9ca7e0a619510a22e256e3e38b5f532624b4aff8964a1e870877b37bc",
-                "sha256:c35c560ef0cb0f133b6104bc374d60eeb7cb69c1d5d7907e4305a285d162bef0"
+                "sha256:84b3fe1727945bc3cada832d969ddb3dc0d08fce1677064ca8bdc13a89c1a143",
+                "sha256:9979fe674780a0b7100eae9156d74ee374cd1638a9f61c77277e3ce712f3e496"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==1.35.6"
+            "version": "==1.35.19"
         },
         "botocore": {
             "hashes": [
-                "sha256:8378c6cfef2dee15eb7b3ebbb55ba9c1de959f231292039b81eb35b72c50ad59",
-                "sha256:93ef31b80b05758db4dd67e010348a05b9ff43f82839629b7ac334f2a454996e"
+                "sha256:42d6d8db7250cbd7899f786f9861e02cab17dc238f64d6acb976098ed9809625",
+                "sha256:c83f7f0cacfe7c19b109b363ebfa8736e570d24922f16ed371681f58ebab44a9"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.35.6"
+            "version": "==1.35.19"
         },
         "certifi": {
             "hashes": [
-                "sha256:5a1e7645bc0ec61a09e26c36f6106dd4cf40c6db3a1fb6352b0244e7fb057c7b",
-                "sha256:c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90"
+                "sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8",
+                "sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2024.7.4"
+            "version": "==2024.8.30"
         },
         "charset-normalizer": {
             "hashes": [
@@ -194,11 +194,11 @@
         },
         "idna": {
             "hashes": [
-                "sha256:050b4e5baadcd44d760cedbd2b8e639f2ff89bbc7a5730fcc662954303377aac",
-                "sha256:d838c2c0ed6fced7693d5e8ab8e734d5f8fda53a039c0164afb0b82e771e3603"
+                "sha256:69297d5da0cc9281c77efffb4e730254dd45943f45bbfb461de5991713989b1e",
+                "sha256:e5c5dafde284f26e9e0f28f6ea2d6400abd5ca099864a67f576f3981c6476124"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.8"
+            "version": "==3.9"
         },
         "itsdangerous": {
             "hashes": [
@@ -547,11 +547,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472",
-                "sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168"
+                "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac",
+                "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==2.2.2"
+            "version": "==2.2.3"
         },
         "werkzeug": {
             "hashes": [
@@ -594,20 +594,20 @@
         },
         "boto3-stubs": {
             "hashes": [
-                "sha256:41d9edea7dced9b3a3a1a79618f3dc0372a25bf7581a119161ba7d095aed19f8",
-                "sha256:a463bb7a07e04256108481127500864201a22e86bb51daec751bac983835a67a"
+                "sha256:6adace32995ae7b88675cf0bbde3b4f31876cbf57520db1ec1f392ac32660b4c",
+                "sha256:c5842cd82d4a1570613f178831c2b6d1b60f511b87f56cc014f2a216c03ecf5a"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==1.35.6"
+            "version": "==1.35.19"
         },
         "botocore-stubs": {
             "hashes": [
-                "sha256:b47baabb66cfc868fb168016e60a83ed6cb2a038bb84ad3e3ae50bce202e6ccd",
-                "sha256:cb7a2372c4b72cc591f54ae878ec1fe73d72d8863e9051eecf9895b09ed760f9"
+                "sha256:91d258c78de2b7359ad6633ee8bc6d4f8d9b746da4d5726f986551e426699fdd",
+                "sha256:ff95ead38bcaf614b0f24c42205441cf04a8cbe22c74bc73f28b2c0a6a0556e0"
             ],
-            "markers": "python_version >= '3.8' and python_version < '4.0'",
-            "version": "==1.35.6"
+            "markers": "python_version >= '3.8'",
+            "version": "==1.35.19"
         },
         "click": {
             "hashes": [
@@ -801,11 +801,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:2d7a1657e36a80ea911db832a8a6ece5ee53d8de21edd5cc5879af6530b1bfee",
-                "sha256:38b7b51f512eed9e84a22788b4bce1de17c0adb134d6becb09836e37d8654cd3"
+                "sha256:50a5450e2e84f44539718293cbb1da0a0885c9d14adf21b77bae4e66fc99d9b5",
+                "sha256:d4e0b7d8ec176b341fb03cb11ca12d0276faa8c485f9cd218f613840463fc2c0"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==4.2.2"
+            "version": "==4.3.3"
         },
         "pluggy": {
             "hashes": [
@@ -833,12 +833,12 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:4ba08f9ae7dcf84ded419494d229b48d0903ea6407b030eaec46df5e6a73bba5",
-                "sha256:c132345d12ce551242c87269de812483f5bcc87cdbb4722e48487ba194f9fdce"
+                "sha256:70b98107bd648308a7952b06e6ca9a50bc660be218d53c257cc1fc94fda10181",
+                "sha256:a6853c7375b2663155079443d2e45de913a911a11d669df02a50814944db57b2"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==8.3.2"
+            "version": "==8.3.3"
         },
         "pytest-cov": {
             "hashes": [
@@ -867,19 +867,19 @@
         },
         "types-awscrt": {
             "hashes": [
-                "sha256:0839fe12f0f914d8f7d63ed777c728cb4eccc2d5d79a26e377d12b0604e7bf0e",
-                "sha256:84a9f4f422ec525c314fdf54c23a1e73edfbcec968560943ca2d41cfae623b38"
+                "sha256:117ff2b1bb657f09d01b7e0ce3fe3fa6e039be12d30b826896182725c9ce85b1",
+                "sha256:9f7f47de68799cb2bcb9e486f48d77b9f58962b92fba43cb8860da70b3c57d1b"
             ],
-            "markers": "python_version >= '3.7' and python_version < '4.0'",
-            "version": "==0.21.2"
+            "markers": "python_version >= '3.8'",
+            "version": "==0.21.5"
         },
         "types-s3transfer": {
             "hashes": [
-                "sha256:02154cce46528287ad76ad1a0153840e0492239a0887e8833466eccf84b98da0",
-                "sha256:49a7c81fa609ac1532f8de3756e64b58afcecad8767933310228002ec7adff74"
+                "sha256:60167a3bfb5c536ec6cdb5818f7f9a28edca9dc3e0b5ff85ae374526fc5e576e",
+                "sha256:7a3fec8cd632e2b5efb665a355ef93c2a87fdd5a45b74a949f95a9e628a86356"
             ],
-            "markers": "python_version >= '3.8' and python_version < '4.0'",
-            "version": "==0.10.1"
+            "markers": "python_version >= '3.8'",
+            "version": "==0.10.2"
         },
         "typing-extensions": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a5f3e6ce43896a52219781d4697a901fbc3f9a416ad46409d77ad73354edda59"
+            "sha256": "ccd1f7b6a6473db853f850bad88f58b220033664bc1d2764653c6c4f99944382"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -38,6 +38,23 @@
                 "sha256:da56b163e5a816e4ad07172f5639287698e09d7f3dc38d18d9726d9c1dbc4cee"
             ],
             "version": "==1.1.4"
+        },
+        "boto3": {
+            "hashes": [
+                "sha256:b41deed9ca7e0a619510a22e256e3e38b5f532624b4aff8964a1e870877b37bc",
+                "sha256:c35c560ef0cb0f133b6104bc374d60eeb7cb69c1d5d7907e4305a285d162bef0"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==1.35.6"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:8378c6cfef2dee15eb7b3ebbb55ba9c1de959f231292039b81eb35b72c50ad59",
+                "sha256:93ef31b80b05758db4dd67e010348a05b9ff43f82839629b7ac334f2a454996e"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.35.6"
         },
         "certifi": {
             "hashes": [
@@ -177,11 +194,11 @@
         },
         "idna": {
             "hashes": [
-                "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc",
-                "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"
+                "sha256:050b4e5baadcd44d760cedbd2b8e639f2ff89bbc7a5730fcc662954303377aac",
+                "sha256:d838c2c0ed6fced7693d5e8ab8e734d5f8fda53a039c0164afb0b82e771e3603"
             ],
-            "markers": "python_version >= '3.5'",
-            "version": "==3.7"
+            "markers": "python_version >= '3.6'",
+            "version": "==3.8"
         },
         "itsdangerous": {
             "hashes": [
@@ -198,6 +215,14 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==3.1.4"
+        },
+        "jmespath": {
+            "hashes": [
+                "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980",
+                "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.0.1"
         },
         "jsonschema": {
             "hashes": [
@@ -504,6 +529,14 @@
             "markers": "python_version >= '3.8'",
             "version": "==0.20.0"
         },
+        "s3transfer": {
+            "hashes": [
+                "sha256:0711534e9356d3cc692fdde846b4a1e4b0cb6519971860796e6bc4c7aea00ef6",
+                "sha256:eca1c20de70a39daee580aef4986996620f365c4e0fda6a86100231d62f1bf69"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.10.2"
+        },
         "six": {
             "hashes": [
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
@@ -517,7 +550,7 @@
                 "sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472",
                 "sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168"
             ],
-            "markers": "python_version >= '3.8'",
+            "markers": "python_version >= '3.10'",
             "version": "==2.2.2"
         },
         "werkzeug": {
@@ -558,6 +591,23 @@
             "index": "pypi",
             "markers": "python_version >= '3.8'",
             "version": "==24.8.0"
+        },
+        "boto3-stubs": {
+            "hashes": [
+                "sha256:41d9edea7dced9b3a3a1a79618f3dc0372a25bf7581a119161ba7d095aed19f8",
+                "sha256:a463bb7a07e04256108481127500864201a22e86bb51daec751bac983835a67a"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==1.35.6"
+        },
+        "botocore-stubs": {
+            "hashes": [
+                "sha256:b47baabb66cfc868fb168016e60a83ed6cb2a038bb84ad3e3ae50bce202e6ccd",
+                "sha256:cb7a2372c4b72cc591f54ae878ec1fe73d72d8863e9051eecf9895b09ed760f9"
+            ],
+            "markers": "python_version >= '3.8' and python_version < '4.0'",
+            "version": "==1.35.6"
         },
         "click": {
             "hashes": [
@@ -693,37 +743,37 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:0624bdb940255d2dd24e829d99a13cfeb72e4e9031f9492148f410ed30bcab54",
-                "sha256:0bc71d1fb27a428139dd78621953effe0d208aed9857cb08d002280b0422003a",
-                "sha256:0bd53faf56de9643336aeea1c925012837432b5faf1701ccca7fde70166ccf72",
-                "sha256:11965c2f571ded6239977b14deebd3f4c3abd9a92398712d6da3a772974fad69",
-                "sha256:1a81cf05975fd61aec5ae16501a091cfb9f605dc3e3c878c0da32f250b74760b",
-                "sha256:2684d3f693073ab89d76da8e3921883019ea8a3ec20fa5d8ecca6a2db4c54bbe",
-                "sha256:2c63350af88f43a66d3dfeeeb8d77af34a4f07d760b9eb3a8697f0386c7590b4",
-                "sha256:45df906e8b6804ef4b666af29a87ad9f5921aad091c79cc38e12198e220beabd",
-                "sha256:4c956b49c5d865394d62941b109728c5c596a415e9c5b2be663dd26a1ff07bc0",
-                "sha256:64f4a90e3ea07f590c5bcf9029035cf0efeae5ba8be511a8caada1a4893f5525",
-                "sha256:749fd3213916f1751fff995fccf20c6195cae941dc968f3aaadf9bb4e430e5a2",
-                "sha256:79c07eb282cb457473add5052b63925e5cc97dfab9812ee65a7c7ab5e3cb551c",
-                "sha256:7b6343d338390bb946d449677726edf60102a1c96079b4f002dedff375953fc5",
-                "sha256:886c9dbecc87b9516eff294541bf7f3655722bf22bb898ee06985cd7269898de",
-                "sha256:a2b43895a0f8154df6519706d9bca8280cda52d3d9d1514b2d9c3e26792a0b74",
-                "sha256:a32fc80b63de4b5b3e65f4be82b4cfa362a46702672aa6a0f443b4689af7008c",
-                "sha256:a707ec1527ffcdd1c784d0924bf5cb15cd7f22683b919668a04d2b9c34549d2e",
-                "sha256:a831671bad47186603872a3abc19634f3011d7f83b083762c942442d51c58d58",
-                "sha256:b639dce63a0b19085213ec5fdd8cffd1d81988f47a2dec7100e93564f3e8fb3b",
-                "sha256:b868d3bcff720dd7217c383474008ddabaf048fad8d78ed948bb4b624870a417",
-                "sha256:c1952f5ea8a5a959b05ed5f16452fddadbaae48b5d39235ab4c3fc444d5fd411",
-                "sha256:d44be7551689d9d47b7abc27c71257adfdb53f03880841a5db15ddb22dc63edb",
-                "sha256:e1e30dc3bfa4e157e53c1d17a0dad20f89dc433393e7702b813c10e200843b03",
-                "sha256:e4fe9f4e5e521b458d8feb52547f4bade7ef8c93238dfb5bbc790d9ff2d770ca",
-                "sha256:f39918a50f74dc5969807dcfaecafa804fa7f90c9d60506835036cc1bc891dc8",
-                "sha256:f404a0b069709f18bbdb702eb3dcfe51910602995de00bd39cea3050b5772d08",
-                "sha256:fca4a60e1dd9fd0193ae0067eaeeb962f2d79e0d9f0f66223a0682f26ffcc809"
+                "sha256:06d26c277962f3fb50e13044674aa10553981ae514288cb7d0a738f495550b36",
+                "sha256:2ff93107f01968ed834f4256bc1fc4475e2fecf6c661260066a985b52741ddce",
+                "sha256:36383a4fcbad95f2657642a07ba22ff797de26277158f1cc7bd234821468b1b6",
+                "sha256:37c7fa6121c1cdfcaac97ce3d3b5588e847aa79b580c1e922bb5d5d2902df19b",
+                "sha256:3a66169b92452f72117e2da3a576087025449018afc2d8e9bfe5ffab865709ca",
+                "sha256:3f14cd3d386ac4d05c5a39a51b84387403dadbd936e17cb35882134d4f8f0d24",
+                "sha256:41ea707d036a5307ac674ea172875f40c9d55c5394f888b168033177fce47383",
+                "sha256:478db5f5036817fe45adb7332d927daa62417159d49783041338921dcf646fc7",
+                "sha256:4a8a53bc3ffbd161b5b2a4fff2f0f1e23a33b0168f1c0778ec70e1a3d66deb86",
+                "sha256:539c570477a96a4e6fb718b8d5c3e0c0eba1f485df13f86d2970c91f0673148d",
+                "sha256:57555a7715c0a34421013144a33d280e73c08df70f3a18a552938587ce9274f4",
+                "sha256:6e658bd2d20565ea86da7d91331b0eed6d2eee22dc031579e6297f3e12c758c8",
+                "sha256:6e7184632d89d677973a14d00ae4d03214c8bc301ceefcdaf5c474866814c987",
+                "sha256:75746e06d5fa1e91bfd5432448d00d34593b52e7e91a187d981d08d1f33d4385",
+                "sha256:7f9993ad3e0ffdc95c2a14b66dee63729f021968bff8ad911867579c65d13a79",
+                "sha256:801780c56d1cdb896eacd5619a83e427ce436d86a3bdf9112527f24a66618fef",
+                "sha256:801ca29f43d5acce85f8e999b1e431fb479cb02d0e11deb7d2abb56bdaf24fd6",
+                "sha256:969ea3ef09617aff826885a22ece0ddef69d95852cdad2f60c8bb06bf1f71f70",
+                "sha256:a976775ab2256aadc6add633d44f100a2517d2388906ec4f13231fafbb0eccca",
+                "sha256:af8d155170fcf87a2afb55b35dc1a0ac21df4431e7d96717621962e4b9192e70",
+                "sha256:b499bc07dbdcd3de92b0a8b29fdf592c111276f6a12fe29c30f6c417dd546d12",
+                "sha256:cd953f221ac1379050a8a646585a29574488974f79d8082cedef62744f0a0104",
+                "sha256:d42a6dd818ffce7be66cce644f1dff482f1d97c53ca70908dff0b9ddc120b77a",
+                "sha256:e8960dbbbf36906c5c0b7f4fbf2f0c7ffb20f4898e6a879fcf56a41a08b0d318",
+                "sha256:edb91dded4df17eae4537668b23f0ff6baf3707683734b6a818d5b9d0c0c31a1",
+                "sha256:ee23de8530d99b6db0573c4ef4bd8f39a2a6f9b60655bf7a1357e585a3486f2b",
+                "sha256:f7821776e5c4286b6a13138cc935e2e9b6fde05e081bdebf5cdb2bb97c9df81d"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==1.11.1"
+            "version": "==1.11.2"
         },
         "mypy-extensions": {
             "hashes": [
@@ -814,6 +864,22 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
+        },
+        "types-awscrt": {
+            "hashes": [
+                "sha256:0839fe12f0f914d8f7d63ed777c728cb4eccc2d5d79a26e377d12b0604e7bf0e",
+                "sha256:84a9f4f422ec525c314fdf54c23a1e73edfbcec968560943ca2d41cfae623b38"
+            ],
+            "markers": "python_version >= '3.7' and python_version < '4.0'",
+            "version": "==0.21.2"
+        },
+        "types-s3transfer": {
+            "hashes": [
+                "sha256:02154cce46528287ad76ad1a0153840e0492239a0887e8833466eccf84b98da0",
+                "sha256:49a7c81fa609ac1532f8de3756e64b58afcecad8767933310228002ec7adff74"
+            ],
+            "markers": "python_version >= '3.8' and python_version < '4.0'",
+            "version": "==0.10.1"
         },
         "typing-extensions": {
             "hashes": [

--- a/serverless.yml
+++ b/serverless.yml
@@ -36,7 +36,11 @@ provider:
             - 'dynamodb:BatchWriteItem'
           Resource:
             - !Sub arn:aws:dynamodb:eu-west-2:${AWS::AccountId}:table/wednesday-api-${sls:stage}-*
-
+        - Effect: Allow
+          Action:
+            - 'ssm:GetParameter'
+          Resource:
+            - !Sub arn:aws:ssm:eu-west-2:${AWS::AccountId}:parameter/${sls:stage}/wednesday-api/*
 package:
   include:
     - "!./**"
@@ -58,12 +62,14 @@ functions:
           path: /{proxy+}
           method: ANY
     environment:
+      STAGE: ${sls:stage}
       DYNAMODB_TABLE_PREFIX: wednesday-api-${sls:stage}
   toot:
     handler: src/toot.toot_random_quote
     events:
       - schedule: cron(0 11 ? * WED *)
     environment:
+      STAGE: ${sls:stage}
       DYNAMODB_TABLE_PREFIX: wednesday-api-${sls:stage}
 
 resources:

--- a/serverless.yml
+++ b/serverless.yml
@@ -3,9 +3,9 @@ app: wednesday-api
 service: wednesday-api
 
 custom:
-  pythonRequirements:
-    dockerizePip: true
-    dockerImage: public.ecr.aws/sam/build-python3.12:1.123.0
+  # pythonRequirements:
+  #   dockerizePip: true
+  #   dockerImage: public.ecr.aws/sam/build-python3.12:1.123.0
   wsgi:
     app: src/api.app
   domain:
@@ -15,13 +15,27 @@ custom:
 provider:
   name: aws
   # Some python depedencies compile code
-  # Architecture must match build machine e.g. arm64 for Macs
-  architecture: arm64
+  # Architecture must match build machine e.g. arm64 for Macs, x86_64 otherwise
+  architecture: x86_64
   runtime: python3.12
   region: eu-west-2
   stage: prod
   memorySize: 128
   endpointType: REGIONAL
+  iam:
+    role:
+      statements:
+        - Effect: Allow
+          Action:
+            - 'dynamodb:Scan'
+            - 'dynamodb:Query'
+            - 'dynamodb:GetItem'
+            - 'dynamodb:UpdateItem'
+            - 'dynamodb:PutItem'
+            - 'dynamodb:BatchGetItem'
+            - 'dynamodb:BatchWriteItem'
+          Resource:
+            - !Sub arn:aws:dynamodb:eu-west-2:${AWS::AccountId}:table/wednesday-api-${sls:stage}-*
 
 package:
   include:
@@ -215,6 +229,36 @@ resources:
                 Ref: ApiOriginRequestPolicy
               CachePolicyId:
                 Ref: ApiCloudfrontCachePolicy
+    QuoteTable:
+      Type: AWS::DynamoDB::Table
+      Properties:
+        BillingMode: "PAY_PER_REQUEST"
+        TableName: wednesday-api-${sls:stage}-quote
+        AttributeDefinitions:
+          - AttributeName: quote_id
+            AttributeType: S
+          - AttributeName: quote_text
+            AttributeType: S
+        KeySchema:
+          - AttributeName: quote_id
+            KeyType: HASH
+          - AttributeName: quote_text
+            KeyType: RANGE
+    QuoteEventTable:
+      Type: AWS::DynamoDB::Table
+      Properties:
+        BillingMode: "PAY_PER_REQUEST"
+        TableName: wednesday-api-${sls:stage}-quote-event
+        AttributeDefinitions:
+          - AttributeName: event_id
+            AttributeType: S
+          - AttributeName: quote_id
+            AttributeType: S
+        KeySchema:
+          - AttributeName: event_id
+            KeyType: HASH
+          - AttributeName: quote_id
+            KeyType: RANGE
   Outputs:
     StaticAssetsBucketName:
       Value: !Ref StaticAssets

--- a/serverless.yml
+++ b/serverless.yml
@@ -57,10 +57,14 @@ functions:
       - http:
           path: /{proxy+}
           method: ANY
+    environment:
+      DYNAMODB_TABLE_PREFIX: wednesday-api-${sls:stage}
   toot:
     handler: src/toot.toot_random_quote
     events:
       - schedule: cron(0 11 ? * WED *)
+    environment:
+      DYNAMODB_TABLE_PREFIX: wednesday-api-${sls:stage}
 
 resources:
   Resources:

--- a/serverless.yml
+++ b/serverless.yml
@@ -235,27 +235,23 @@ resources:
         BillingMode: "PAY_PER_REQUEST"
         TableName: wednesday-api-${sls:stage}-quote
         AttributeDefinitions:
-          - AttributeName: quote_id
-            AttributeType: S
-          - AttributeName: quote_text
+          - AttributeName: id
             AttributeType: S
         KeySchema:
-          - AttributeName: quote_id
+          - AttributeName: id
             KeyType: HASH
-          - AttributeName: quote_text
-            KeyType: RANGE
     QuoteEventTable:
       Type: AWS::DynamoDB::Table
       Properties:
         BillingMode: "PAY_PER_REQUEST"
         TableName: wednesday-api-${sls:stage}-quote-event
         AttributeDefinitions:
-          - AttributeName: event_id
+          - AttributeName: id
             AttributeType: S
           - AttributeName: quote_id
             AttributeType: S
         KeySchema:
-          - AttributeName: event_id
+          - AttributeName: id
             KeyType: HASH
           - AttributeName: quote_id
             KeyType: RANGE

--- a/src/api.py
+++ b/src/api.py
@@ -118,7 +118,7 @@ def quote_index(quote_id):
         quote = dynamodb.get_quote(quote_id=quote_id)
         response = {"data": quote}
         return jsonify(response)
-    except IndexError:
+    except KeyError:
         logging.debug("No quote found")
         return make_response(jsonify(error="Quote not found!"), 404)
 

--- a/src/api.py
+++ b/src/api.py
@@ -85,8 +85,10 @@ def quote_random():
         schema:
           $ref: '#/definitions/Quote'
     """
-    random_quote = random.choice(dynamodb.get_quotes())
-    return jsonify(random_quote)
+    quote = random.choice(dynamodb.get_quotes(start_id=None)[0])
+    print(quote)
+    response = {"data": quote}
+    return jsonify(response)
 
 
 @api.route("/quotes/<string:quote_id>")
@@ -114,7 +116,8 @@ def quote_index(quote_id):
     """
     try:
         quote = dynamodb.get_quote(quote_id=quote_id)
-        return jsonify(quote)
+        response = {"data": quote}
+        return jsonify(response)
     except IndexError:
         logging.debug("No quote found")
         return make_response(jsonify(error="Quote not found!"), 404)

--- a/src/api.py
+++ b/src/api.py
@@ -47,7 +47,7 @@ def quotes():
     """
     start_id = request.args.get("start_id")
     quotes, last_evaluated_key = dynamodb.get_quotes(start_id=start_id)
-    api_root = "https://devapi.wednesday.zone/v1"
+    api_root = f"{request.url_root}v1"
     response = {
         "links": {
             "self": (

--- a/src/api.py
+++ b/src/api.py
@@ -4,7 +4,7 @@ import random
 from flasgger import Swagger
 from flask import Blueprint, Flask, jsonify, make_response
 
-from utils import utils
+from utils import dynamodb
 
 app = Flask(__name__)
 app.config["SWAGGER"] = {
@@ -45,7 +45,7 @@ def quote():
         schema:
           $ref: '#/definitions/QuoteList'
     """
-    quotes = utils.load_quotes()
+    quotes = dynamodb.get_quotes()
     return jsonify(quotes)
 
 
@@ -67,18 +67,18 @@ def quote_random():
         schema:
           $ref: '#/definitions/Quote'
     """
-    random_quote = random.choice(utils.load_quotes())
+    random_quote = random.choice(dynamodb.get_quotes())
     return jsonify(random_quote)
 
 
-@api.route("/quote/<int:index>")
-def quote_index(index):
+@api.route("/quote/<string:quote_id>")
+def quote_index(quote_id):
     """Returns a specific quote.
     ---
     parameters:
-      - name: index
+      - name: quote_id
         in: path
-        type: integer
+        type: string
         required: true
     definitions:
       Quote:
@@ -95,7 +95,7 @@ def quote_index(index):
           $ref: '#/definitions/Quote'
     """
     try:
-        quote = utils.load_quotes()[index]
+        quote = dynamodb.get_quote(quote_id=quote_id)
         return jsonify(quote)
     except IndexError:
         logging.debug("No quote found")

--- a/src/toot.py
+++ b/src/toot.py
@@ -4,7 +4,7 @@ import random
 
 from mastodon import Mastodon
 
-from utils import utils
+from utils import dynamodb, utils
 
 if logging.getLogger().hasHandlers():
     # The Lambda environment pre-configures a handler logging to stderr. If a handler is already configured,
@@ -21,7 +21,7 @@ def toot_quote(quote_dict):
     )
 
     # Toot
-    toot_text = quote_dict["quote"]
+    toot_text = quote_dict["text"]
     if "attribution" in quote_dict and quote_dict["attribution"]:
         toot_text = toot_text + " - " + quote_dict["attribution"]
 
@@ -29,9 +29,9 @@ def toot_quote(quote_dict):
     mastodon.status_post(toot_text)
 
 
-def toot_random_quote(event=None, context=None):
-    if utils.is_it_wednesday():
-        random_quote = random.choice(utils.load_quotes())
+def toot_random_quote(event=None, context=None, fake_wednesday=False):
+    if utils.is_it_wednesday(fake_wednesday=fake_wednesday):
+        random_quote = random.choice(dynamodb.get_quotes(start_id=None, limit=False)[0])
         toot_quote(random_quote)
     else:
         logging.info("Not tooting because it is not Wednesday")

--- a/src/toot.py
+++ b/src/toot.py
@@ -32,7 +32,18 @@ def toot_quote(quote_dict):
 
 def toot_random_quote(event=None, context=None, fake_wednesday=False):
     if utils.is_it_wednesday(fake_wednesday=fake_wednesday):
-        random_quote = random.choice(dynamodb.get_quotes(start_id=None, limit=False)[0])
-        toot_quote(random_quote)
+        quote_list = dynamodb.get_quotes(start_id=None, limit=False)[0]
+
+        posted = False
+        while not posted and quote_list:
+            random_quote = random.choice(quote_list)
+            print(random_quote)
+            if not dynamodb.check_quote_posted(random_quote["id"]):
+                toot_quote(random_quote)
+                posted = True
+            else:
+                quote_list.remove(random_quote)
+        if not posted:
+            logging.error("Could not find quote we haven't posted")
     else:
         logging.info("Not tooting because it is not Wednesday")

--- a/src/toot.py
+++ b/src/toot.py
@@ -2,6 +2,7 @@ import logging
 import os
 import random
 
+import boto3
 from mastodon import Mastodon
 
 from utils import dynamodb, utils
@@ -15,9 +16,19 @@ else:
 
 
 def toot_quote(quote_dict):
+    stage = os.getenv("STAGE", "dev")
+    client = boto3.client("ssm")
+    access_token_parameter = client.get_parameter(
+        Name=f"/{stage}/wednesday-api/MASTODON_ACCESS_TOKEN"
+    )
+    access_token_value = access_token_parameter["Parameter"]["Value"]
+    base_url_parameter = client.get_parameter(
+        Name=f"/{stage}/wednesday-api/MASTODON_BASE_URL"
+    )
+    base_url_value = base_url_parameter["Parameter"]["Value"]
     mastodon = Mastodon(
-        access_token=os.environ.get("MASTODON_ACCESS_TOKEN", ""),
-        api_base_url=os.environ.get("MASTODON_BASE_URL", ""),
+        access_token=access_token_value,
+        api_base_url=base_url_value,
     )
 
     # Toot

--- a/src/toot.py
+++ b/src/toot.py
@@ -27,6 +27,7 @@ def toot_quote(quote_dict):
 
     logging.info(f"Tooting quote: {toot_text}")
     mastodon.status_post(toot_text)
+    dynamodb.audit_event(quote_dict["id"], "posted")
 
 
 def toot_random_quote(event=None, context=None, fake_wednesday=False):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -49,6 +49,5 @@ def test_request_quote_id(client):
     # When getting an invalid id we get an error
     response = client.get("/v1/quotes/randomshiz")
     response_json = json.loads(response.data)
-    print(response_json)
     assert len(response_json.keys()) == 1
     assert response_json["error"] == "Quote not found!"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -47,7 +47,7 @@ def test_request_quote_id(client):
         assert "added" in quote
 
     # When getting an invalid id we get an error
-    response = client.get(f"/v1/quotes/randomshiz")
+    response = client.get("/v1/quotes/randomshiz")
     response_json = json.loads(response.data)
     print(response_json)
     assert len(response_json.keys()) == 1

--- a/tests/test_toot.py
+++ b/tests/test_toot.py
@@ -1,7 +1,5 @@
 from unittest.mock import MagicMock, patch
 
-from freezegun import freeze_time
-
 from src.toot import toot_quote, toot_random_quote
 
 
@@ -9,13 +7,12 @@ from src.toot import toot_quote, toot_random_quote
 def test_toot_quote(MockMastodon):
     mastodon = MockMastodon()
     mastodon.status_post = MagicMock(return_value=True)
-    toot_quote({"quote": "my quote", "attribution": "author name"})
+    toot_quote({"text": "my quote", "attribution": "author name"})
     mastodon.status_post.assert_called_once_with("my quote - author name")
 
 
-@freeze_time("2024-08-21")
 @patch("src.toot.toot_quote")
 def test_toot_random_quote(mock_toot_quote):
     mock_toot_quote.return_value = True
-    toot_random_quote()
+    toot_random_quote(fake_wednesday=True)
     mock_toot_quote.assert_called_once()

--- a/tests/test_toot.py
+++ b/tests/test_toot.py
@@ -7,7 +7,7 @@ from src.toot import toot_quote, toot_random_quote
 def test_toot_quote(MockMastodon):
     mastodon = MockMastodon()
     mastodon.status_post = MagicMock(return_value=True)
-    toot_quote({"text": "my quote", "attribution": "author name"})
+    toot_quote({"id": "testid", "text": "my quote", "attribution": "author name"})
     mastodon.status_post.assert_called_once_with("my quote - author name")
 
 

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -4,7 +4,7 @@ import uuid
 import pytest
 from freezegun import freeze_time
 
-from utils.utils import is_it_wednesday, load_quotes
+from utils.utils import is_it_wednesday, load_quotes_from_csv
 
 
 @pytest.fixture
@@ -17,12 +17,12 @@ def setup_quote_file():
     os.remove(temp_path)
 
 
-def test_load_quotes(setup_quote_file):
+def test_load_quotes_from_csv(setup_quote_file):
     """
     Check that quotes get loaded
     """
 
-    quotes = load_quotes(setup_quote_file)
+    quotes = load_quotes_from_csv(setup_quote_file)
     expected_list = [
         {"quote": "quote number one", "attribution": "author"},
         {"quote": "quote number two", "attribution": "author two"},

--- a/utils/dynamodb.py
+++ b/utils/dynamodb.py
@@ -1,0 +1,64 @@
+import logging
+import uuid
+from datetime import datetime
+
+import boto3
+from boto3.dynamodb.conditions import Key
+
+from utils.utils import load_quotes_from_csv
+
+dynamodb = boto3.resource(
+    "dynamodb",
+    region_name="eu-west-2",
+)
+
+
+def store_quote(quote_text: str, quote_attribution: str):
+    table = dynamodb.Table("wednesday-api-dev-quote")
+    now = datetime.utcnow()
+    quote_id = str(uuid.uuid4())
+    response = table.update_item(
+        Key={
+            "quote_id": quote_id,
+            "quote_text": quote_text,
+        },
+        UpdateExpression="SET quote_added = :quote_added, quote_attribution = :quote_attribution",
+        ExpressionAttributeValues={
+            ":quote_added": now.isoformat(),
+            ":quote_attribution": quote_attribution,
+        },
+    )
+    audit_event(quote_id=quote_id, event_type="added", event_timestamp=now.isoformat())
+    return response
+
+
+def audit_event(quote_id: str, event_type: str, event_timestamp):
+    event_table = dynamodb.Table("wednesday-api-dev-quote-event")
+    return event_table.update_item(
+        Key={"event_id": f"{quote_id}-added-{uuid.uuid4()}", "quote_id": quote_id},
+        UpdateExpression="SET event_type = :event_type, event_timestamp = :event_timestamp",
+        ExpressionAttributeValues={
+            ":event_type": event_type,
+            ":event_timestamp": event_timestamp,
+        },
+    )
+
+
+def get_quotes():
+    table = dynamodb.Table("wednesday-api-dev-quote")
+    response = table.scan()
+    quote_list = response["Items"]
+    return quote_list
+
+
+def get_quote(quote_id: str):
+    table = dynamodb.Table("wednesday-api-dev-quote")
+    response = table.query(KeyConditionExpression=Key("quote_id").eq(quote_id))
+    return response["Items"][0]
+
+
+def import_quotes(path="./wednesday.csv"):
+    quote_list = load_quotes_from_csv(path=path)
+    for quote in quote_list:
+        store_quote(quote_text=quote["quote"], quote_attribution=quote["attribution"])
+        logging.info(f"Storing quote {quote}")

--- a/utils/dynamodb.py
+++ b/utils/dynamodb.py
@@ -1,7 +1,7 @@
+import datetime
 import logging
 import os
 import uuid
-from datetime import datetime
 
 import boto3
 
@@ -16,7 +16,7 @@ dynamodb_table_prefix = os.getenv("DYNAMODB_TABLE_PREFIX", "wednesday-api-dev")
 
 def store_quote(quote_text: str, quote_attribution: str):
     table = dynamodb.Table(f"{dynamodb_table_prefix}-quote")
-    now = datetime.now(datetime.timezone.utc)
+    now = datetime.datetime.now(datetime.timezone.utc)
     quote_id = str(uuid.uuid4())
     response = table.update_item(
         Key={"id": quote_id},
@@ -43,12 +43,16 @@ def audit_event(quote_id: str, event_type: str, event_timestamp):
     )
 
 
-def get_quotes(start_id: str):
+def get_quotes(start_id: str, limit: bool = True):
     table = dynamodb.Table(f"{dynamodb_table_prefix}-quote")
     if start_id:
         response = table.scan(Limit=50, ExclusiveStartKey={"id": start_id})
     else:
-        response = table.scan(Limit=50)
+        if limit:
+            response = table.scan(Limit=50)
+        else:
+            response = table.scan()
+
     response_items = response["Items"]
     last_evaluated_key = (
         response["LastEvaluatedKey"] if "LastEvaluatedKey" in response else None

--- a/utils/dynamodb.py
+++ b/utils/dynamodb.py
@@ -47,17 +47,33 @@ def get_quotes(start_id: str):
         response = table.scan(Limit=50, ExclusiveStartKey={"id": start_id})
     else:
         response = table.scan(Limit=50)
-    quote_list = response["Items"]
+    response_items = response["Items"]
     last_evaluated_key = (
         response["LastEvaluatedKey"] if "LastEvaluatedKey" in response else None
     )
+    quote_list = []
+    for quote in response_items:
+        quote_list.append(
+            {
+                "id": quote["id"],
+                "added": quote["quote_added"],
+                "text": quote["quote_text"],
+                "attribution": quote["quote_attribution"],
+            }
+        )
     return quote_list, last_evaluated_key
 
 
 def get_quote(quote_id: str):
     table = dynamodb.Table("wednesday-api-dev-quote")
     response = table.get_item(Key={"id": quote_id})
-    return response["Items"]
+    quote = response["Item"]
+    return {
+        "id": quote["id"],
+        "added": quote["quote_added"],
+        "text": quote["quote_text"],
+        "attribution": quote["quote_attribution"],
+    }
 
 
 def import_quotes(path="./wednesday.csv"):

--- a/utils/dynamodb.py
+++ b/utils/dynamodb.py
@@ -5,6 +5,7 @@ import uuid
 from typing import Optional
 
 import boto3
+from boto3.dynamodb.conditions import Attr
 
 from utils.utils import load_quotes_from_csv
 
@@ -93,3 +94,13 @@ def import_quotes(path="./wednesday.csv"):
     for quote in quote_list:
         store_quote(quote_text=quote["quote"], quote_attribution=quote["attribution"])
         logging.info(f"Storing quote {quote}")
+
+
+def check_quote_posted(quote_id: str):
+    event_table = dynamodb.Table(f"{dynamodb_table_prefix}-quote-event")
+    filter_expression = Attr("quote_id").eq(quote_id) & Attr("event_type").eq("posted")
+    response = event_table.scan(FilterExpression=filter_expression)
+    response_items = response["Items"]
+    if response_items:
+        return True
+    return False

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -3,7 +3,7 @@ import os
 from datetime import datetime
 
 
-def load_quotes(path="./wednesday.csv"):
+def load_quotes_from_csv(path="./wednesday.csv"):
     # Read in the CSV to a list of dicts
     wednesday_list = []
     with open(path, newline="") as csvfile:


### PR DESCRIPTION
Avoid duplicate toots by using DynamoDB to store both the quotes and events. Every time we go to post a toot it will check that hasn't already been posted and pick a different one if it has. The only downside of this is that if we don't have enough new quotes added, eventually it will run out of fresh ones and just won't post at all.

I also changed the api a bit to meet some kind of standard for REST apis but haven't updated the API docs yet...sorry...not that anyone is using the API yet anyway.